### PR TITLE
Update workflow to account for newly added pages

### DIFF
--- a/.github/workflows/core-pr-link-checker.yml
+++ b/.github/workflows/core-pr-link-checker.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           mkdocs build -d site
 
-      - name: 'Convert added pages to excluded URLs'
+      - name: Convert Added Pages to Excluded URLs
         id: ignore_links
         if: ${{ inputs.url != '' }}
         run: |

--- a/.github/workflows/core-pr-link-checker.yml
+++ b/.github/workflows/core-pr-link-checker.yml
@@ -18,6 +18,9 @@ on:
       root_dir:
         required: false
         type: string
+      url:
+        required: false
+        type: string
     secrets:
       GH_TOKEN:
         required: true
@@ -37,7 +40,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.docs_repo }}
-          path: '${{ inputs.mkdocs_repo_name}}/${{ inputs.docs_repo_name}}'
+          path: ${{ inputs.mkdocs_repo_name }}/${{ inputs.docs_repo_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: 'Get Added Markdown Files for Exclusion'
+        id: added_pages
+        working-directory: >-
+          ${{ inputs.mkdocs_repo_name }}/${{ inputs.docs_repo_name }}
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.ref }}"
+          git fetch origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+          git diff --name-status origin/$BASE_REF...HEAD | \
+            awk '$1 == "A" && $2 ~ /\.md$/ {print $2}' > /tmp/added_pages.txt
 
       - name: 'Set up Python'
         uses: actions/setup-python@v5
@@ -45,34 +60,49 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
-      - name: 'Install dependencies'
+      - name: 'Install Dependencies'
         working-directory: ${{ inputs.mkdocs_repo_name }}
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: 'Build MkDocs site'
+      - name: 'Build MkDocs Site'
         working-directory: ${{ inputs.mkdocs_repo_name }}
         run: |
           mkdocs build -d site
 
-      - name: Prepare Lychee Arguments
+      - name: 'Convert Added Pages to Excluded URLs'
+        id: ignore_links
+        if: ${{ inputs.url != '' }}
+        run: |
+          IGNORED_LINKS=""
+          while read -r FILE; do
+            [ -z "$FILE" ] && continue
+            PATH=$(echo "$FILE" | sed -e 's/^docs\///' \
+              -e 's/index\.md$//' -e 's/\.md$//')
+            URL="${{ inputs.url }}/${PATH}/"
+            IGNORED_LINKS="$IGNORED_LINKS --exclude $URL"
+          done < /tmp/added_pages.txt
+          echo "ignored=$IGNORED_LINKS" >> $GITHUB_OUTPUT
+
+      - name: 'Prepare Lychee Arguments'
         id: lychee_args
         run: |
-          ARGS="--root-dir $(pwd)/${{ inputs.mkdocs_repo_name }}/site --no-progress --accept 429,403"
+          ARGS="--root-dir $(pwd)/${{ inputs.mkdocs_repo_name }}/site \
+            --no-progress --accept 429,403"
           if [[ -f "$(pwd)/${{ inputs.mkdocs_repo_name }}/.urlignore" ]]; then
             echo "Found .urlignore file. Adding to lychee arguments."
-            ARGS="$ARGS --exclude-file $(pwd)/${{ inputs.mkdocs_repo_name }}/.urlignore"
+            ARGS="$ARGS --exclude-file \
+              $(pwd)/${{ inputs.mkdocs_repo_name }}/.urlignore"
           fi
           echo "args=$ARGS" >> $GITHUB_OUTPUT
 
-      # Run the link checker (lychee) on the built MkDocs site.
       - name: 'Run Link Checker (lychee)'
         id: lychee
         uses: lycheeverse/lychee-action@v2.4.1
         with:
           args: >
             ${{ steps.lychee_args.outputs.args }}
+            ${{ steps.ignore_links.outputs.ignored }}
             './${{ inputs.mkdocs_repo_name }}/site/**/*.html'
           fail: true
-        continue-on-error: false

--- a/.github/workflows/core-pr-link-checker.yml
+++ b/.github/workflows/core-pr-link-checker.yml
@@ -106,3 +106,4 @@ jobs:
             ${{ steps.ignore_links.outputs.ignored }}
             './${{ inputs.mkdocs_repo_name }}/site/**/*.html'
           fail: true
+        continue-on-error: false

--- a/.github/workflows/core-pr-link-checker.yml
+++ b/.github/workflows/core-pr-link-checker.yml
@@ -35,8 +35,7 @@ jobs:
           repository: ${{ inputs.mkdocs_repo }}
           path: ${{ inputs.mkdocs_repo_name }}
 
-      - name: 'Checkout Docs Repo'
-        if: ${{ inputs.docs_repo != inputs.mkdocs_repo }}
+      - name: 'Checkout Docs Repo into MkDocs'
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.docs_repo }}
@@ -44,7 +43,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
-      - name: 'Get Added Markdown Files for Exclusion'
+      - name: 'Get added Markdown files for exclusion'
         id: added_pages
         working-directory: >-
           ${{ inputs.mkdocs_repo_name }}/${{ inputs.docs_repo_name }}
@@ -54,35 +53,58 @@ jobs:
           git diff --name-status origin/$BASE_REF...HEAD | \
             awk '$1 == "A" && $2 ~ /\.md$/ {print $2}' > /tmp/added_pages.txt
 
+          # Display the added pages
+          ADDED_COUNT=$(wc -l < /tmp/added_pages.txt)
+          echo "📄 Found $ADDED_COUNT added markdown files in this PR:"
+
+          if [ -s /tmp/added_pages.txt ]; then
+            while IFS= read -r file; do
+              echo "  ✅ $file"
+            done < /tmp/added_pages.txt
+          else
+            echo "  (No new markdown files added)"
+          fi
+
       - name: 'Set up Python'
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
 
-      - name: 'Install Dependencies'
+      - name: 'Install dependencies'
         working-directory: ${{ inputs.mkdocs_repo_name }}
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: 'Build MkDocs Site'
+      - name: 'Build MkDocs site'
         working-directory: ${{ inputs.mkdocs_repo_name }}
         run: |
           mkdocs build -d site
 
-      - name: 'Convert Added Pages to Excluded URLs'
+      - name: 'Convert added pages to excluded URLs'
         id: ignore_links
         if: ${{ inputs.url != '' }}
         run: |
           IGNORED_LINKS=""
+          EXCLUDED_COUNT=0
+
+          echo "🔗 Converting added markdown files to excluded URLs:"
+          echo "   Base URL: ${{ inputs.url }}"
+          echo ""
+
           while read -r FILE; do
             [ -z "$FILE" ] && continue
             PATH=$(echo "$FILE" | sed -e 's/^docs\///' \
               -e 's/index\.md$//' -e 's/\.md$//')
             URL="${{ inputs.url }}/${PATH}/"
             IGNORED_LINKS="$IGNORED_LINKS --exclude $URL"
+            EXCLUDED_COUNT=$((EXCLUDED_COUNT + 1))
+            echo "  🚫 $FILE → $URL"
           done < /tmp/added_pages.txt
+
+          echo ""
+          echo "📊 Summary: Excluding $EXCLUDED_COUNT URLs from link checking"
           echo "ignored=$IGNORED_LINKS" >> $GITHUB_OUTPUT
 
       - name: 'Prepare Lychee Arguments'


### PR DESCRIPTION
This pull request updates the `.github/workflows/core-pr-link-checker.yml` file to enhance its functionality for handling pull requests in documentation repositories. The key changes include adding support for excluding specific URLs from link checking, improving the handling of markdown files added in pull requests, and refining the workflow's structure.

### Enhancements to URL exclusion and link checking:

* Added an optional `url` input parameter to allow exclusion of specific URLs during link checking. This input is used to dynamically generate exclusion arguments for the Lychee link checker.
* Introduced a new step, `Convert Added Pages to Excluded URLs`, which processes added markdown files in the pull request to create exclusion URLs based on the provided `url` input.

### Improvements to handling pull request changes:

* Added a step, `Get Added Markdown Files for Exclusion`, to identify markdown files added in the pull request and store their paths for further processing.
* Updated the checkout step to fetch the pull request's head reference and set `fetch-depth` to 0 for complete history, ensuring accurate diff calculations.

### Workflow structure refinements:

* Adjusted naming conventions for steps (e.g., `Install Dependencies`, `Build MkDocs Site`) to maintain consistency and clarity.
* Improved formatting and readability of commands in multiple steps, such as breaking long arguments into multi-line strings.

---

Below is an example of a new page being detected and ignored:

<img width="810" height="506" alt="Screenshot 2025-07-11 at 2 32 11 PM" src="https://github.com/user-attachments/assets/41a62a75-2b18-4470-bf79-83336cf24c18" />
