### PR TITLE
Adding pr-blocked-label workflow

### DIFF
--- a/.github/workflows/pr-blocked-label.yml
+++ b/.github/workflows/pr-blocked-label.yml
@@ -1,6 +1,12 @@
 name: Prevent Merge on Blocked PRs
 
 on:
+  workflow_call:
+    inputs:
+      blocking_labels:
+        description: 'Comma-separated list of labels that should block PR merging'
+        required: true
+        type: string
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize, reopened]
 
@@ -8,21 +14,23 @@ jobs:
   check-label:
     runs-on: ubuntu-latest
     steps:
-      - name: Check for "B2 - Blocked" label
+      - name: Check for blocking labels
         uses: actions/github-script@v7
         with:
           script: |
-            const labelToBlock = "B2 - Blocked";
+            const blockingLabels = "${{ inputs.blocking_labels }}".split(',').map(label => label.trim());
             const prNumber = context.payload.pull_request.number;
-
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber
             });
-
-            const hasBlockLabel = labels.some(label => label.name === labelToBlock);
-
-            if (hasBlockLabel) {
-              core.setFailed(`PR cannot be merged because it has the label "${labelToBlock}"`);
+            
+            const foundBlockingLabels = labels.filter(label => 
+              blockingLabels.includes(label.name)
+            );
+            
+            if (foundBlockingLabels.length > 0) {
+              const foundLabelNames = foundBlockingLabels.map(label => label.name).join(', ');
+              core.setFailed(`PR cannot be merged because it has the following blocking label(s): "${foundLabelNames}"`);
             }

--- a/.github/workflows/pr-blocked-label.yml
+++ b/.github/workflows/pr-blocked-label.yml
@@ -5,9 +5,8 @@ on:
     inputs:
       whitelist_labels:
         description: 'Comma-separated list of labels that are required for PR merging'
-        required: false
+        required: true
         type: string
-        default: ''
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize, reopened]
 
@@ -19,15 +18,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const whitelistLabels = "${{ inputs.whitelist_labels }}".split(',').map(label => label.trim()).filter(label => label.length > 0);
+            const whitelistLabels = "${{ inputs.whitelist_labels }}".split(',').map(label => label.trim());
             const prNumber = context.payload.pull_request.number;
-            
-            // If no whitelist labels are configured, skip the check
-            if (whitelistLabels.length === 0) {
-              console.log('No whitelist labels configured. Skipping label check.');
-              return;
-            }
-            
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/pr-blocked-label.yml
+++ b/.github/workflows/pr-blocked-label.yml
@@ -1,0 +1,29 @@
+name: Prevent Merge on Blocked PRs
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize, reopened]
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for "B2 - Blocked" label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const labelToBlock = "B2 - Blocked";
+            const prNumber = context.payload.pull_request.number;
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+
+            const hasBlockLabel = labels.some(label => label.name === labelToBlock);
+
+            if (hasBlockLabel) {
+              core.setFailed(`PR cannot be merged because it has the label "${labelToBlock}"`);
+            }

--- a/.github/workflows/pr-blocked-label.yml
+++ b/.github/workflows/pr-blocked-label.yml
@@ -11,7 +11,6 @@ jobs:
       - name: Check for "B2 - Blocked" label
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const labelToBlock = "B2 - Blocked";
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/pr-blocked-label.yml
+++ b/.github/workflows/pr-blocked-label.yml
@@ -1,10 +1,10 @@
-name: Prevent Merge on Blocked PRs
+name: Prevent Merge on Non-Whitelisted PRs
 
 on:
   workflow_call:
     inputs:
-      blocking_labels:
-        description: 'Comma-separated list of labels that should block PR merging'
+      whitelist_labels:
+        description: 'Comma-separated list of labels that are required for PR merging'
         required: true
         type: string
   pull_request:
@@ -14,11 +14,11 @@ jobs:
   check-label:
     runs-on: ubuntu-latest
     steps:
-      - name: Check for blocking labels
+      - name: Check for whitelist labels
         uses: actions/github-script@v7
         with:
           script: |
-            const blockingLabels = "${{ inputs.blocking_labels }}".split(',').map(label => label.trim());
+            const whitelistLabels = "${{ inputs.whitelist_labels }}".split(',').map(label => label.trim());
             const prNumber = context.payload.pull_request.number;
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
@@ -26,11 +26,11 @@ jobs:
               issue_number: prNumber
             });
             
-            const foundBlockingLabels = labels.filter(label => 
-              blockingLabels.includes(label.name)
+            const foundWhitelistLabels = labels.filter(label => 
+              whitelistLabels.includes(label.name)
             );
             
-            if (foundBlockingLabels.length > 0) {
-              const foundLabelNames = foundBlockingLabels.map(label => label.name).join(', ');
-              core.setFailed(`PR cannot be merged because it has the following blocking label(s): "${foundLabelNames}"`);
+            if (foundWhitelistLabels.length === 0) {
+              const requiredLabelNames = whitelistLabels.join(', ');
+              core.setFailed(`PR cannot be merged because it must have at least one of the following labels: "${requiredLabelNames}"`);
             }

--- a/.github/workflows/pr-blocked-label.yml
+++ b/.github/workflows/pr-blocked-label.yml
@@ -5,8 +5,9 @@ on:
     inputs:
       whitelist_labels:
         description: 'Comma-separated list of labels that are required for PR merging'
-        required: true
+        required: false
         type: string
+        default: ''
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize, reopened]
 
@@ -18,8 +19,15 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const whitelistLabels = "${{ inputs.whitelist_labels }}".split(',').map(label => label.trim());
+            const whitelistLabels = "${{ inputs.whitelist_labels }}".split(',').map(label => label.trim()).filter(label => label.length > 0);
             const prNumber = context.payload.pull_request.number;
+            
+            // If no whitelist labels are configured, skip the check
+            if (whitelistLabels.length === 0) {
+              console.log('No whitelist labels configured. Skipping label check.');
+              return;
+            }
+            
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to prevent merging pull requests labeled as "B2 - Blocked." The workflow ensures that PRs with this label cannot proceed to merge, improving process control and enforcing team policies.

### New workflow addition:
* [`.github/workflows/pr-blocked-label.yml`](diffhunk://#diff-f4dcad0404db6b58033acae21c21cebaca34ad3b94b85c7813e8c5c074fe2c32R1-R29): Added a GitHub Actions workflow named "Prevent Merge on Blocked PRs." This workflow triggers on various pull request events (e.g., labeled, opened, edited) and checks for the presence of the "B2 - Blocked" label. If the label is present, the workflow fails, preventing the PR from being merged.