### PR TITLE
papermoon-mkdocs-plugins==0.1.0a11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ mkdocs-redirects==1.2.2
 mkdocs-static-i18n==1.3.0
 neoteroi-mkdocs==1.1.0
 nltk==3.9.1
-papermoon-mkdocs-plugins==0.1.0a10
+papermoon-mkdocs-plugins==0.1.0a11
 Pillow==11.3.0
 polib==1.2.0
 Pygments==2.19.1


### PR DESCRIPTION
This PR bumps the Papermoon plugin to a new version.